### PR TITLE
Format Hive Chicago Buzz session data on the fly

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -47,7 +47,7 @@
                     </div>
                     <div id="page-links">
                         <a href="./img/HiveChicagoBuzzFloorPlan.pdf">Floor Plan</a>
-                        <a href="#_pathways" id="pathways-page-link">Moonshots</a>
+                        <a href="#_moonshots" id="pathways-page-link">Moonshots</a>
                     </div>
                 </div>
             </nav>
@@ -63,36 +63,36 @@
         <script type="text/template" id="session-list-template">
         <div id="friday" class="schedule-tab">
             <h3><span>Friday Doors Open 4 PM</span></h3>
-            <div id="friday-doors-open" class="page-block"><div class="open-block">OPEN</div></div>
+            <div id="friday-400-pm-doors-open" class="page-block"><div class="open-block">OPEN</div></div>
 
             <h3><span>Friday Keynotes 5 PM</span></h3>
-            <div id="friday-keynotes" class="page-block"><div class="open-block">OPEN</div></div>
+            <div id="friday-500-pm-keynotes" class="page-block"><div class="open-block">OPEN</div></div>
 
             <h3><span>Friday Networking 6 PM</span></h3>
-            <div id="friday-networking" class="page-block"><div class="open-block">OPEN</div></div>
+            <div id="friday-600-pm-networking" class="page-block"><div class="open-block">OPEN</div></div>
         </div>
 
         <div id="saturday" class="schedule-tab">
             <h3><span>Saturday Opening 8:30 AM</span></h3>
-            <div id="saturday-opening" class="page-block"><div class="open-block">OPEN</div></div>
+            <div id="saturday-830-am-opening" class="page-block"><div class="open-block">OPEN</div></div>
 
             <h3><span>Saturday Skillshare 9 AM</span></h3>
-            <div id="saturday-skillshare-1" class="page-block"><div class="open-block">OPEN</div></div>
+            <div id="saturday-900-am-skillshare" class="page-block"><div class="open-block">OPEN</div></div>
 
             <h3><span>Saturday Skillshare 10 AM</span></h3>
-            <div id="saturday-skillshare-2" class="page-block"><div class="open-block">OPEN</div></div>
+            <div id="saturday-1000-am-skillshare" class="page-block"><div class="open-block">OPEN</div></div>
 
             <h3><span>Saturday Working Group 11 AM</span></h3>
-            <div id="saturday-working-group" class="page-block"><div class="open-block">OPEN</div></div>
+            <div id="saturday-1100-am-working-group" class="page-block"><div class="open-block">OPEN</div></div>
 
             <h3><span>Saturday Grab 'N Go Lunch 12 PM</span></h3>
-            <div id="saturday-lunch" class="page-block"><div class="open-block">OPEN</div></div>
+            <div id="saturday-1200-pm-grab-n-go-lunch" class="page-block"><div class="open-block">OPEN</div></div>
 
             <h3><span>Saturday Cake & Refreshments 3:30 PM</span></h3>
-            <div id="saturday-cake" class="page-block"><div class="open-block">OPEN</div></div>
+            <div id="saturday-330-pm-cake-refreshments" class="page-block"><div class="open-block">OPEN</div></div>
 
             <h3><span>Saturday CLosing 4 PM</span></h3>
-            <div id="saturday-closing" class="page-block"><div class="open-block">OPEN</div></div>
+            <div id="saturday-400-pm-closing" class="page-block"><div class="open-block">OPEN</div></div>
         </div>
 
         <div id="sunday" class="schedule-tab">
@@ -182,7 +182,7 @@
                     <% if (session.pathways && session.pathwayArray.length) { %>
                     <div class="session-pathways">
                         <% session.pathwayArray.forEach(function(name, index) { %><% if (index > 0) { %>, <% } %>
-                            <a href="#_pathway-<%= slugify(name) %>"><%= name %></a><% }) %>
+                            <a href="#_moonshot-<%= slugify(name) %>"><%= name %></a><% }) %>
                     </div>
                     <% } %>
                     <% if (session.facilitators) { %>
@@ -217,7 +217,7 @@
 
         <script type="text/template" id="pathways-list-template">
             <% if (name) { %>
-            <a href="#_pathway-<%= slugify(name) %>" class="pathway-list-item" data-pathway="<%= slugify(name) %>">
+            <a href="#_moonshot-<%= slugify(name) %>" class="pathway-list-item" data-pathway="<%= slugify(name) %>">
                 <h4><%= name %></h4>
                 <p><%= numSessions %> session<% if (numSessions>1) { %>s<% } %></p>
                 <% if (description.length) { %><% description.forEach(function(p) { %>

--- a/public/js/schedule.js
+++ b/public/js/schedule.js
@@ -79,11 +79,11 @@ function Schedule(options) {
                 // show sessions in a space based on space slug in URL
                 schedule.displaySessionsOfSpace(pageID);
                 break;
-            case "_pathways":
+            case "_moonshots":
                 // shows list of all pathways
                 schedule.displayPathwaysList();
                 break;
-            case "_pathway":
+            case "_moonshot":
                 // show sessions in a pathway based on pathway slug in URL
                 schedule.getFilteredSessions("pathways", pageID);
                 break;
@@ -166,12 +166,13 @@ function Schedule(options) {
         }
     }
 
-
     // sortSessionGroups() performs basic sorting so session lists
     // are rendered in proper order
     // TODO: pass in a sorting function rather than hard-code it here
     schedule.sortSessionGroups = function(data) {
         schedule.sessionList = _.sortBy(data, function(i) {
+            // FIXME: temp solution for formatting Hive Chicago Buzz data
+            i = formatHiveChicagoBuzzData(i);
             // simple way to divide sessions into groups by length
             return i.length != '1 hour';
         });
@@ -963,6 +964,24 @@ marked.setOptions({
     tables: false,
     smartypants: true
 });
+
+// FIXME: definitely a temp solution for formatting Hive Chicago Buzz session data exported from
+// Google Spreadsheet so that it's in the format the MozFest Schedule App consumes
+function formatHiveChicagoBuzzData(session) {
+    session.facilitator1 = session.facilitator1 || "";
+    session.facilitator2 = session.facilitator2 || "";
+    session.facilitator3 = session.facilitator3 || "";
+    var formatted = _.extend(session, {
+        id: session.id.toString(),
+        pathways: session.moonshot || "",
+        scheduleblock: !!session.scheduleblock ? session.scheduleblock.toLowerCase().replace(/ /g,"-").replace(/\(/g,"").replace(/\)/g,"").replace(/:/g,'').replace(/\'/g,'').replace(/\&/g,'') : "",
+        facilitator_array: [session.facilitator1, session.facilitator2, session.facilitator3].filter(function(facilitator){
+                                return !!facilitator;
+                            }),
+    });
+    formatted.facilitators = formatted.facilitator_array.join(",");
+    return formatted;
+}
 
 // instantiate the app
 new Schedule();


### PR DESCRIPTION
Fixes #9.

This way we don't have to modify the original MozFest Schedule App code too much & we don't have to manually format every entry in `sessions.json` by hand. It takes data exported from @edrushka 's exciting Google Spreadsheet (via [google-spreadsheet-to-json](https://github.com/bassarisse/google-spreadsheet-to-json)) and map object properties into MozFest app format.

Definitely a temp solution just for the Hive Chicago Buzz app to be up within this tight timeframe. :wink: 

/cc @ScottDowne 
